### PR TITLE
feat: add webview component

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -13,6 +13,7 @@ import OTPInputViews from '~/views/OTPInput';
 import PageViews from '~/views/Page';
 import TextViews from '~/views/Text';
 import ViewViews from '~/views/View';
+import WebViewViews from '~/views/WebView';
 
 const Stack = createNativeStackNavigator();
 
@@ -31,6 +32,7 @@ const App = () => {
         <Stack.Screen name="Page" component={PageViews} />
         <Stack.Screen name="Text" component={TextViews} />
         <Stack.Screen name="View" component={ViewViews} />
+        <Stack.Screen name="WebView" component={WebViewViews} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.reactnativecommunity.webview.RNCWebViewPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'example'
+include ':react-native-webview'
+project(':react-native-webview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -12,6 +12,8 @@ target 'example' do
     :hermes_enabled => false
   )
 
+  pod 'react-native-webview', :path => '../node_modules/react-native-webview'
+
   target 'exampleTests' do
     inherit! :complete
     # Pods for testing

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,8 @@
     "react": "17.0.2",
     "react-native": "0.66.4",
     "react-native-safe-area-context": "^3.3.2",
-    "react-native-screens": "^3.10.2"
+    "react-native-screens": "^3.10.2",
+    "react-native-webview": "^11.17.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/example/src/views/Home/index.tsx
+++ b/example/src/views/Home/index.tsx
@@ -37,6 +37,10 @@ const HomeView: React.FC = () => {
       <ButtonView title="Page" onPress={() => navigation.navigate('Page')} />
       <ButtonView title="Text" onPress={() => navigation.navigate('Text')} />
       <ButtonView title="View" onPress={() => navigation.navigate('View')} />
+      <ButtonView
+        title="WebView"
+        onPress={() => navigation.navigate('WebView')}
+      />
     </BaseLayout>
   );
 };

--- a/example/src/views/WebView/index.tsx
+++ b/example/src/views/WebView/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {WebView} from '@jitera/jitera-rn-ui-library';
+import {WebView as RNWebView} from 'react-native-webview';
+
+const WebViewViews: React.FC = () => (
+  <WebView
+    Component={RNWebView}
+    source={{uri: 'https://jitera.com/'}}
+    style={{width: '100%', height: '100%'}}
+  />
+);
+
+export default WebViewViews;

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "compilerOptions": {
     /* Basic Options */

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1036,6 +1036,7 @@
     react-native-safe-area-context "^3.3.2"
     react-native-size-matters "^0.4.0"
     react-native-vector-icons "^9.0.0"
+    react-native-webview "^11.16.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2760,15 +2761,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-escape-string-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -3626,7 +3627,7 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -5742,6 +5743,22 @@ react-native-vector-icons@^9.0.0:
     lodash.template "^4.5.0"
     prop-types "^15.7.2"
     yargs "^16.1.1"
+
+react-native-webview@^11.16.0:
+  version "11.16.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.16.0.tgz#51dce13480aa4f8f727307df05b8bfaf74ca3d14"
+  integrity sha512-yap3dO3adMQp4z5oDzlcgcv6XPsfHAtt1E3ort94GthrunswaZhL6AfMiDOsNnKQmlUA+o4LNJsnlAy1b10rUg==
+  dependencies:
+    escape-string-regexp "2.0.0"
+    invariant "2.2.4"
+
+react-native-webview@^11.17.0:
+  version "11.17.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.17.0.tgz#318ee8314662866148ca2b8db07549038e1c0c64"
+  integrity sha512-mm6XYOne4K0c9eYOArmJOuo9fOUeESB7DT+xihLcX84qMTsepPTcnkKha5BxuFwlvKKlSj4KzgkUMl15Mhbvdw==
+  dependencies:
+    escape-string-regexp "2.0.0"
+    invariant "2.2.4"
 
 react-native@0.66.4:
   version "0.66.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jitera/jitera-rn-ui-library",
-  "version": "0.0.11-alpha",
+  "version": "0.0.12-alpha",
   "description": "atoms and component for rn template project and web",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -74,6 +74,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
+    "react-native": "*",
     "react-native-webview": "*"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-native": "*"
+    "react-native-webview": "*"
   },
   "jest": {
     "preset": "react-native",

--- a/src/components/atoms/WebView/Component.tsx
+++ b/src/components/atoms/WebView/Component.tsx
@@ -1,0 +1,19 @@
+import React, { forwardRef } from 'react';
+
+import type { WebView as RNWebView } from 'react-native-webview';
+import type { WebViewProps as RNWebViewProps } from 'react-native-webview';
+import type { PropsWithRef } from '../../../type';
+
+export type WebViewProps = PropsWithRef<
+  {
+    Component: typeof RNWebView;
+  } & RNWebViewProps
+>;
+
+const WebView: React.FC<WebViewProps> = forwardRef<RNWebView, WebViewProps>(
+  ({ Component, ...props }, ref) => <Component ref={ref} {...props} />
+);
+
+WebView.displayName = 'WebView';
+
+export default WebView;

--- a/src/components/atoms/WebView/ThemedComponent.tsx
+++ b/src/components/atoms/WebView/ThemedComponent.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import WebView from './Component';
+
+import type { WebViewProps } from './Component';
+import type { RneFunctionComponent } from '../../../theme/helpers';
+
+const ThemedWebView: RneFunctionComponent<Omit<WebViewProps, 'ref'>> = (
+  props
+) => <WebView {...props} />;
+
+ThemedWebView.displayName = 'WebView';
+
+export default WebView;

--- a/src/components/atoms/WebView/index.tsx
+++ b/src/components/atoms/WebView/index.tsx
@@ -1,0 +1,8 @@
+import WebView from './Component';
+import { withTheme } from '../../../theme';
+
+import type { WebViewProps } from './Component';
+
+export { WebView };
+export type { WebViewProps };
+export default withTheme(WebView, 'WebView');

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import Icon, { IconProps } from './components/atoms/Icon';
 import Header, { HeaderProps } from './components/atoms/Header';
 import OTPInput, { OTPInputProps } from './components/atoms/OTPInput';
 import Divider, { DividerProps } from './components/atoms/Divider';
+import WebView, { WebViewProps } from './components/atoms/WebView';
 
 import CommonLoading, {
   CommonLoadingProps,
@@ -64,6 +65,7 @@ export {
   CommonLoading,
   Toast,
   Modal,
+  WebView,
 };
 
 // Atoms Components Props exports
@@ -81,6 +83,7 @@ export type {
   CommonLoadingProps,
   ToastProps,
   ModalProps,
+  WebViewProps,
 };
 
 export default components;

--- a/src/previewComponents.ts
+++ b/src/previewComponents.ts
@@ -8,6 +8,7 @@ import Icon from './components/atoms/Icon/Component';
 import Header from './components/atoms/Header/Component';
 import OTPInput from './components/atoms/OTPInput/Component';
 import Divider from './components/atoms/Divider/Component';
+import WebView from './components/atoms/WebView';
 
 export default {
   Button,
@@ -20,4 +21,5 @@ export default {
   Header,
   OTPInput,
   Divider,
+  WebView,
 };

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -7,6 +7,7 @@ import type {
   IconProps,
   PageProps,
   DividerProps,
+  WebViewProps,
 } from '../';
 import type {
   ModalProps,
@@ -47,6 +48,7 @@ export interface FullTheme {
   fonts: Partial<FontTypes>;
   safeArea: Partial<SafeAreaSize>;
   Divider: Partial<DividerProps>;
+  WebView: Partial<WebViewProps>;
 }
 
 export type Theme<T = any> = Partial<FullTheme> & T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3891,15 +3891,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-
-escape-string-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -5168,7 +5168,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -7915,6 +7915,14 @@ react-native-vector-icons@^9.0.0:
     lodash.template "^4.5.0"
     prop-types "^15.7.2"
     yargs "^16.1.1"
+
+react-native-webview@^11.16.0:
+  version "11.16.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.16.0.tgz#51dce13480aa4f8f727307df05b8bfaf74ca3d14"
+  integrity sha512-yap3dO3adMQp4z5oDzlcgcv6XPsfHAtt1E3ort94GthrunswaZhL6AfMiDOsNnKQmlUA+o4LNJsnlAy1b10rUg==
+  dependencies:
+    escape-string-regexp "2.0.0"
+    invariant "2.2.4"
 
 react-native@0.63.4:
   version "0.63.4"


### PR DESCRIPTION
## Description

Close: https://github.com/Jitera/jitera-frontend/issues/79

This PR add webview component. We can't directly render the component inside jitera-rn-ui-library since we need to link react-native-webview on project level.

In order to render the webview, the developer need to import the component on project level and pass it as `Component` props to our `Webview` wrapper component. Inside the wrapper component, we render that props value.

```tsx
import React from 'react';
import {WebView} from '@jitera/jitera-rn-ui-library';
import {WebView as RNWebView} from 'react-native-webview';

const WebViewViews: React.FC = () => (
  <WebView
    Component={RNWebView}
    source={{uri: 'https://jitera.com/'}}
    style={{width: '100%', height: '100%'}}
  />
);

export default WebViewViews;
```

https://user-images.githubusercontent.com/20434351/150073806-3b61cde2-6401-45da-ab83-21835389ebba.mp4

