### PR TITLE
fix: remove default margin for divider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jitera/jitera-rn-ui-library",
-  "version": "0.0.18-alpha",
+  "version": "0.0.19-alpha",
   "description": "atoms and component for rn template project and web",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/atoms/Divider/Component.tsx
+++ b/src/components/atoms/Divider/Component.tsx
@@ -68,7 +68,6 @@ const Divider: FunctionComponent<DividerProps> = forwardRef<any, DividerProps>(
 const defaultStyles = StyleSheet.create({
   container: {
     position: 'relative',
-    marginVertical: 10,
   },
   lineContainer: {
     position: 'absolute',


### PR DESCRIPTION
Relate issue
[Included both top and bottom margin after adding component](https://app.zenhub.com/workspaces/project-jitera-po-sieu-60e7ddd474722d001198aa7e/issues/jitera/jitera-frontend/588)

Now we remove default marginVertical for divider