### PR TITLE
fix(header): display incorrectly on ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jitera/jitera-rn-ui-library",
-  "version": "0.0.37-alpha",
+  "version": "0.0.38-alpha",
   "description": "atoms and component for rn template project and web",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/atoms/Header/Component.tsx
+++ b/src/components/atoms/Header/Component.tsx
@@ -145,10 +145,7 @@ const Header: FunctionComponent<HeaderProps> = forwardRef<any, HeaderProps>(
     };
 
     const renderInside = () => {
-      const defaultHeight =
-        height ||
-        (Platform.OS === 'web' ? 45 : defaultTheme?.spacing?.SPACING_45);
-
+      const safeAreaSpace = (unsafe ? safeAreaTop : 0)
       return (
         <View
           ref={ref}
@@ -156,8 +153,7 @@ const Header: FunctionComponent<HeaderProps> = forwardRef<any, HeaderProps>(
             styles.wrapper,
             {
               backgroundColor,
-              height: defaultHeight,
-              paddingTop: unsafe ? safeAreaTop : 0,
+              paddingTop: Platform.OS === 'web' ? 8 : (defaultTheme?.spacing?.SPACING_8 + safeAreaSpace),
             },
             style,
           ]}
@@ -188,6 +184,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderColor: 'rgba(0,0,0,0.1)',
     alignItems: 'center',
+    paddingBottom: Platform.OS === 'web' ? 8 : defaultTheme?.spacing?.SPACING_8
   },
   leftWrapper: {
     flex: 0.2,


### PR DESCRIPTION
Web
![header](https://user-images.githubusercontent.com/20434351/156683740-e03f403e-fd11-452d-bb86-645199dbb9e6.png)

iOS
<img width="404" alt="Image from iOS" src="https://user-images.githubusercontent.com/20434351/156683767-78862958-507b-44bb-b16e-4d0cc071ce8c.png">

Android
<img width="341" alt="Image from iOS (1)" src="https://user-images.githubusercontent.com/20434351/156683777-dc2b134f-419b-4ba2-a2cf-08abf4b62916.png">

